### PR TITLE
jcommon 1.0.16 isn't yet in maven central

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -155,6 +155,7 @@
             </plugin>
         </plugins>
     </build>
+    
     <repositories>
         <repository>
           <id>osgeo</id>
@@ -162,6 +163,7 @@
           <url>http://download.osgeo.org/webdav/geotools/</url>
         </repository>
     </repositories>
+    
     <dependencies>
         <!-- Compile -->
         <dependency>


### PR DESCRIPTION
When I built the project for the first time, the jcommon dependency could not be satisfied.  It appears as though 1.0.16 is not yet in maven central.  However, the osgeo repository does have it.  I'm proposing that the osgeo repository be added until such time as 1.0.16 is available in maven central to make initial checkout and build smoother.
